### PR TITLE
Added meta tag theme-color

### DIFF
--- a/src/layouts/default.html.eco
+++ b/src/layouts/default.html.eco
@@ -9,6 +9,7 @@
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="<%= @document.url %>"/>
     <meta property="og:image" content="<%= @document.image %>"/>
+    <meta name="theme-color" content="#000e4f"/>
 
     <meta name="description"
           content="A #LaraconfBrasil e a primeira conferencia realizada com foco totalmente em Laravel e na comunidade PHP. E você vai ficar de fora ? Reserve na sua agenda os dias 17 e 18 de novembro de 2017">

--- a/src/layouts/default.html.eco
+++ b/src/layouts/default.html.eco
@@ -8,7 +8,7 @@
     <meta property="og:title" content="<%= @document.title %>"/>
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="<%= @document.url %>"/>
-    <meta property="og:image" content="<%= @document.image %>"/>    
+    <meta property="og:image" content="<%= @document.image %>"/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@laraconfbrazil"/>
     <meta name="theme-color" content="#000e4f"/>


### PR DESCRIPTION
Added a meta tag called `theme-color`, that customize the tab color on mobile browsers.

Docs: [Google Web Fundamentals guide](https://developers.google.com/web/fundamentals/design-and-ux/browser-customization/#color_browser_elements).